### PR TITLE
Update choco package to 99.31

### DIFF
--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.24</version>
+    <version>0.99.25</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -7,7 +7,7 @@
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>
     <authors>Giuseppe Penone</authors>
-    <projectUrl>https://www.giuspen.com/cherrytree/</projectUrl>
+    <projectUrl>https://github.com/giuspen/cherrytree</projectUrl>
     <licenseUrl>https://raw.githubusercontent.com/giuspen/cherrytree/master/license.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/giuspen/cherrytree</projectSourceUrl>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -7,7 +7,7 @@
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>
     <authors>Giuseppe Penone</authors>
-    <projectUrl>https://www.giuspen.com/cherrytree</projectUrl>
+    <projectUrl>https://www.giuspen.com/cherrytree/</projectUrl>
     <licenseUrl>https://raw.githubusercontent.com/giuspen/cherrytree/master/license.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/giuspen/cherrytree</projectSourceUrl>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.17</version>
+    <version>0.99.18</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.16</version>
+    <version>0.99.17</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.25</version>
+    <version>0.99.27</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.27</version>
+    <version>0.99.28</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.28</version>
+    <version>0.99.31</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>cherrytree</id>
+    <version>0.38.8</version>
+    <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
+    <owners>ao123123</owners>
+    <title>cherrytree (Install)</title>
+    <authors>Giuseppe Penone</authors>
+    <projectUrl>https://www.giuspen.com/cherrytree</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/giuspen/cherrytree/master/license.txt</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/giuspen/cherrytree</projectSourceUrl>
+    <docsUrl>http://giuspen.com/cherrytreemanual/</docsUrl>
+    <bugTrackerUrl>https://github.com/giuspen/cherrytree/issues</bugTrackerUrl>
+    <tags>cherrytree notes foss</tags>
+    <summary>A hierarchical note taking application, featuring rich text and syntax highlighting, storing data in a single xml or sqlite file.</summary>
+    <description>Cherrytree is a free and open source, hierarchical, note-taking application. It can store text, images, files, links, tables, and executable snippets of code. This application is under active development.</description>
+
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.19</version>
+    <version>0.99.24</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -16,7 +16,7 @@
     <tags>cherrytree notes foss</tags>
     <summary>A hierarchical note taking application, featuring rich text and syntax highlighting, storing data in a single xml or sqlite file.</summary>
     <description>Cherrytree is a free and open source, hierarchical, note-taking application. It can store text, images, files, links, tables, and executable snippets of code. This application is under active development.</description>
-
+    <iconUrl>https://www.giuspen.com/icons_softw/cherrytree.png</iconUrl>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.38.11</version>
+    <version>0.39.2</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.38.8</version>
+    <version>0.38.9</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.38.9</version>
+    <version>0.38.11</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.39.4</version>
+    <version>0.99.14</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.14</version>
+    <version>0.99.16</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.99.18</version>
+    <version>0.99.19</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/cherrytree.nuspec
+++ b/windows/chocolatey/cherrytree.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cherrytree</id>
-    <version>0.39.2</version>
+    <version>0.39.4</version>
     <packageSourceUrl>https://github.com/trololo88/cherrytree/tree/master/windows/chocolatey</packageSourceUrl>
     <owners>ao123123</owners>
     <title>cherrytree (Install)</title>

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'http://www.giuspen.com/software/cherrytree_0.38.9_setup.exe'
+$url        = 'http://www.giuspen.com/software/cherrytree_0.38.11_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = 'ff4249aaec02fe785dce1ae7f2c3f45fa6718bfeabf4b33156639c13bbeadafb'
+  checksum      = '271eed3106396add2ee7c1062dc70e15952563a63082915f4cce498508ba20ab'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'http://www.giuspen.com/software/cherrytree_0.38.8_setup.exe'
+$url        = 'http://www.giuspen.com/software/cherrytree_0.38.9_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = '4ee0c5b050e72025d61706950f4f9ccdc04812abad8545770385fa948dd39b43'
+  checksum      = 'ff4249aaec02fe785dce1ae7f2c3f45fa6718bfeabf4b33156639c13bbeadafb'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.39.4_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.14.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = '5284979c2944010b3a55a6aeda83329655ee49d7e892fafec81094c20c242cdf'
+  checksum      = 'ff7a7363d60ea387dc014486cef874c2562d19720f4eac107eb02d5adfd36ec2'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'http://www.giuspen.com/software/cherrytree_0.38.11_setup.exe'
+$url        = 'http://www.giuspen.com/software/cherrytree_0.39.2_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = '271eed3106396add2ee7c1062dc70e15952563a63082915f4cce498508ba20ab'
+  checksum      = '945a9edd672e76a5e3919d525dc449a904c957577c8905a5d952b133cb768130'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.17.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.18.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = 'e72d1b6d45aca84c3c8f5bd77a346ac4ae54adf3ada31c3e0b0364f201a2580a'
+  checksum      = 'ff3fb13fd3b6e3cb1fc10bcd456a220011eaf182aeb44018de60f6d81578fa3b'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.28.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.31.0_win64_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = '855bbfa5ad2fc5aacb22f505c7c597eb0475990546e5aad08479c2895cbde81f'
+  checksum      = '3a3c939bdac6cc1f538b21194744f35f8f1264600bc254d7e1fc6d712dd0d560'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.16.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.17.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = '7dec833759ddb582d992884f2c66b4fce58353c1ca527571d5ed36b16bed61d4'
+  checksum      = 'e72d1b6d45aca84c3c8f5bd77a346ac4ae54adf3ada31c3e0b0364f201a2580a'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.24.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.25.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = 'd49ee4f73e2bad47eeb26d85c571ccdec02795837f0a1415adb93781fa049d9a'
+  checksum      = '00d7dbfe5276abbad2fac76af9178d8e33f92addd7c57aa1202c36e0b466c33a'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'http://www.giuspen.com/software/cherrytree_0.39.2_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.39.4_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = '945a9edd672e76a5e3919d525dc449a904c957577c8905a5d952b133cb768130'
+  checksum      = '5284979c2944010b3a55a6aeda83329655ee49d7e892fafec81094c20c242cdf'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.25.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.27.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = '00d7dbfe5276abbad2fac76af9178d8e33f92addd7c57aa1202c36e0b466c33a'
+  checksum      = 'c2f6065624f1ce89157cfe0f7e605115003eaf2442b956215456e3ca8e19c930'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.27.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.28.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = 'c2f6065624f1ce89157cfe0f7e605115003eaf2442b956215456e3ca8e19c930'
+  checksum      = '855bbfa5ad2fc5aacb22f505c7c597eb0475990546e5aad08479c2895cbde81f'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.14.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.16.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = 'ff7a7363d60ea387dc014486cef874c2562d19720f4eac107eb02d5adfd36ec2'
+  checksum      = '7dec833759ddb582d992884f2c66b4fce58353c1ca527571d5ed36b16bed61d4'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.18.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.19.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = 'ff3fb13fd3b6e3cb1fc10bcd456a220011eaf182aeb44018de60f6d81578fa3b'
+  checksum      = 'f705cafef6a76298b16c84332e9504314eb1d5d7f2977e8ce573d7e7427a8e46'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'cherrytree'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.giuspen.com/software/cherrytree_0.99.19.0_setup.exe'
+$url        = 'https://www.giuspen.com/software/cherrytree_0.99.24.0_setup.exe'
 
 $packageArgs = @{
   packageName   = $packageName
   url           = $url
   silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
   softwareName  = 'Cherrytree*'
-  checksum      = 'f705cafef6a76298b16c84332e9504314eb1d5d7f2977e8ce573d7e7427a8e46'
+  checksum      = 'd49ee4f73e2bad47eeb26d85c571ccdec02795837f0a1415adb93781fa049d9a'
   checksumType  = 'sha256'
 }
 

--- a/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,14 @@
+﻿$packageName= 'cherrytree'
+$toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
+$url        = 'http://www.giuspen.com/software/cherrytree_0.38.8_setup.exe'
+
+$packageArgs = @{
+  packageName   = $packageName
+  url           = $url
+  silentArgs    = "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT"
+  softwareName  = 'Cherrytree*'
+  checksum      = '4ee0c5b050e72025d61706950f4f9ccdc04812abad8545770385fa948dd39b43'
+  checksumType  = 'sha256'
+}
+
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
- Guispen changed win download URL to include win64 in name
- Checksum taken from here: https://www.giuspen.com/cherrytree/#downl
- I am not sure how to test this locally and have no previous experience with choco. But It can't find old URL on guispen website, so I assume this might solve it. 